### PR TITLE
Nts/fix duplication when persisting core entities

### DIFF
--- a/src-v2/Judge/NTS.Judge.Blazor/Pages/Dashboard/Handouts/HandoutsList.razor
+++ b/src-v2/Judge/NTS.Judge.Blazor/Pages/Dashboard/Handouts/HandoutsList.razor
@@ -8,9 +8,8 @@
     <MudItem xs="11">
         <MudPaper Elevation="1" Class="pa-4">
             <MudStack>
-                @foreach (var handout in _behind.Handouts)
+                @foreach (var document in _behind.Documents)
                 {
-                    var document = new HandoutDocument(handout, _behind.EnduranceEvent!, _behind.Officials);
                     var header = document.Header;
                     <MudItem>
                         <MudItem Class="d-flex flex-row">
@@ -54,8 +53,8 @@
                             </MudItem>
 
                             <MudItem>
-                                <MudText Typo="Typo.h5">@($"{handout.Tandem.Number} {handout.Tandem.Name}, {handout.Tandem.Horse}")</MudText>
-                                <ParticipationTable Phases="handout.Phases"/>
+                                <MudText Typo="Typo.h5">@($"{document.Tandem.Number} {document.Tandem.Name}, {document.Tandem.Horse}")</MudText>
+                                <ParticipationTable Phases="document.Phases"/>
                             </MudItem>
                         </MudItem>
                     </MudItem>

--- a/src-v2/Judge/NTS.Judge.Blazor/Pages/Dashboard/Ranklist/RanklistRow.razor
+++ b/src-v2/Judge/NTS.Judge.Blazor/Pages/Dashboard/Ranklist/RanklistRow.razor
@@ -2,81 +2,97 @@
 @using NTS.Domain.Core.Entities
 @using NTS.Domain.Objects
 @using NTS.Judge.Blazor.Pages.Dashboard.Components
+@using NTS.Judge.Blazor.Ports
 
-<RanklistTableFrame>
-    <One>
-        @if (_notQualified != null)
-        {
-            <MudText Typo="Typo.caption" Class="mr-4 pl-2" Style="width: 1rem;">@_notQualified</MudText>
-            <MudIcon Icon="@Icons.Material.TwoTone.Flag" Color="Color.Error" Size="Size.Large" />
-        }
-        else if (Entry.Participation.Phases.Any(x => !x.IsComplete))
-        {
-            <MudIcon Icon="@Icons.Material.TwoTone.Flag" Color="Color.Default" Size="Size.Large" />
-        }
-        else
-        {
-            <MudText Class="mr-4 pl-2" Style="width: 1rem;">@_rank</MudText>
-            <MudIcon Icon="@Icons.Material.Filled.Flag" Color="Color.Success" Size="Size.Large" />
-        }
-    </One>
-    <Two>
-        <MudStack>
-            <MudItem>
-                <MudText><strong>@_tandem.Number</strong> @_tandem.Name</MudText>
-            </MudItem>
-            <MudItem>
-                <MudText>@_tandem.Horse</MudText>
-            </MudItem>
-        </MudStack>
-    </Two>
-    <Three>
-        @_currentPhase?.ArriveTime
-    </Three>
-    <Four>
-        @Entry.Participation.Total?.AverageSpeed
-    </Four>
-    <Five>
-        @Entry.Participation.Total?.RideInterval
-    </Five>
-    <Six>
-        @Entry.Participation.Total?.RecoveryIntervalWithoutFinal
-    </Six>
-    <Seven>
-        @_totalInterval
-    </Seven>
-    <Eight>
-        <MudIcon Icon="@(_expanded ? Icons.Material.Filled.KeyboardArrowDown : @Icons.Material.Filled.KeyboardArrowRight)"
-                 @onclick="Toggle"
-                 Style="width:100%; cursor:pointer;" />
-    </Eight>
-</RanklistTableFrame>
-<MudCollapse Expanded="_expanded">
-    <MudDivider />
-    <ParticipationTable Phases="Entry.Participation.Phases" />
-</MudCollapse>
+@if (_phases != null)
+{
+    <RanklistTableFrame>
+        <One>
+            @if (_notQualified != null)
+            {
+                <MudText Typo="Typo.caption" Class="mr-4 pl-2" Style="width: 1rem;">@_notQualified</MudText>
+                <MudIcon Icon="@Icons.Material.TwoTone.Flag" Color="Color.Error" Size="Size.Large" />
+            }
+            else if (_phases.Any(x => !x.IsComplete))
+            {
+                <MudIcon Icon="@Icons.Material.TwoTone.Flag" Color="Color.Default" Size="Size.Large" />
+            }
+            else
+            {
+                <MudText Class="mr-4 pl-2" Style="width: 1rem;">@_rank</MudText>
+                <MudIcon Icon="@Icons.Material.Filled.Flag" Color="Color.Success" Size="Size.Large" />
+            }
+        </One>
+        <Two>
+            <MudStack>
+                <MudItem>
+                    <MudText><strong>@_tandem.Number</strong> @_tandem.Name</MudText>
+                </MudItem>
+                <MudItem>
+                    <MudText>@_tandem.Horse</MudText>
+                </MudItem>
+            </MudStack>
+        </Two>
+        <Three>
+            @_phases.Current?.ArriveTime
+        </Three>
+        <Four>
+            @_total?.AverageSpeed
+        </Four>
+        <Five>
+            @_total?.RideInterval
+        </Five>
+        <Six>
+            @_total?.RecoveryIntervalWithoutFinal
+        </Six>
+        <Seven>
+            @_totalInterval
+        </Seven>
+        <Eight>
+            <MudIcon Icon="@(_expanded ? Icons.Material.Filled.KeyboardArrowDown : @Icons.Material.Filled.KeyboardArrowRight)"
+                     @onclick="Toggle"
+                     Style="width:100%; cursor:pointer;" />
+        </Eight>
+    </RanklistTableFrame>
+    <MudCollapse Expanded="_expanded">
+        <MudDivider />
+        <ParticipationTable Phases="_phases" />
+    </MudCollapse>
+}
 
 @code {
     private bool _expanded;
-    private Tandem _tandem => Entry.Participation.Tandem;
-    private NotQualified? _notQualified => Entry.Participation.NotQualified;
-    private Phase? _currentPhase => Entry.Participation.Phases.CurrentComplete;
+    private PhaseCollection _phases = default!;
+    private Tandem _tandem = default!;
+    private NotQualified _notQualified = default!;
+    private Total? _total;
+    private TimeInterval? _totalInterval;
     private string? _rank;
-    private TimeInterval? _totalInterval => Entry.Participation.Total?.RideInterval + Entry.Participation.Total?.RecoveryIntervalWithoutFinal;
 
     [Parameter]
     public RankingEntry Entry { get; set; } = default!;
     [Parameter]
     public int Index { get; set; } = default!;
+    [Inject]
+    IParticipationBehind _behind { get; set; } = default!;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        var participation = await _behind.Get(Entry.ParticipationId);
+        GuardHelper.ThrowIfDefault(participation);
+
+        _phases = participation.Phases;
+        _tandem = participation.Tandem;
+        _notQualified = participation.NotQualified;
+        _total = participation.Total;
+        _totalInterval = participation.Total?.RideInterval + participation.Total?.RecoveryIntervalWithoutFinal;
+
         if (!Entry.IsRanked)
         {
             _rank = "unranked";
             return;
         }
-        if (Entry.Participation.IsNotQualified)
+        if (participation.IsNotQualified)
         {
             _rank = null;
             return;

--- a/src-v2/Judge/NTS.Judge.Blazor/Ports/IHandoutsBehind.cs
+++ b/src-v2/Judge/NTS.Judge.Blazor/Ports/IHandoutsBehind.cs
@@ -1,14 +1,14 @@
 ﻿using Not.Blazor.Ports.Behinds;
 using Not.Injection;
 using Not.Startup;
-using NTS.Domain.Core.Entities;
+using NTS.Domain.Core.Aggregates.Participations;
+using NTS.Domain.Core.Objects;
 
 namespace NTS.Judge.Blazor.Ports;
 
 public interface IHandoutsBehind : IStartupInitializer, IObservableBehind, ISingletonService
 {
-    Event? EnduranceEvent { get; }
-    IEnumerable<Official> Officials { get; }
-    IReadOnlyList<Handout> Handouts { get; }
-    Task<IEnumerable<Handout>> PopAll();
+    IReadOnlyList<HandoutDocument> Documents { get; }
+    Task<IEnumerable<HandoutDocument>> PopAll();
+    Task<Participation?> GetParticipation(int id);
 }

--- a/src-v2/Judge/NTS.Judge.Blazor/Ports/IParticipationBehind.cs
+++ b/src-v2/Judge/NTS.Judge.Blazor/Ports/IParticipationBehind.cs
@@ -14,4 +14,5 @@ public interface IParticipationBehind : IObservableBehind
     Task Update(IPhaseState state);
     Task RevokeQualification(int number, QualificationRevokeType type, FTQCodes? ftqCodes = null, string? reason = null);
     Task RestoreQualification(int number);
+    Task<Participation?> Get(int id);
 }

--- a/src-v2/Judge/NTS.Judge/ACL/EmsToCoreImporter.cs
+++ b/src-v2/Judge/NTS.Judge/ACL/EmsToCoreImporter.cs
@@ -46,8 +46,7 @@ public class EmsToCoreImporter : IEmsToCoreImporter
         var @event = CreateEvent(emsState.Event, adjustTime);
         //TODOL interesting why some imports fail without ToList? 2024-vakarel (finished) for example
         var officials = CreateOfficials(emsState.Event).ToList();
-        var participations = CreateParticipations(emsState, adjustTime).ToList();
-        var classifications = CreateClassifications(emsState, adjustTime).ToList();
+        var (rankings, participations) = CreateRankingsAndParticipations(emsState, adjustTime);
 
         await _events.Create(@event);
         foreach (var official in officials)
@@ -58,7 +57,7 @@ public class EmsToCoreImporter : IEmsToCoreImporter
         {
             await _participations.Create(participation);
         }
-        foreach (var classification in classifications)
+        foreach (var classification in rankings)
         {
             await _classfications.Create(classification);
         }
@@ -119,22 +118,10 @@ public class EmsToCoreImporter : IEmsToCoreImporter
         return result;
     }
 
-    private IEnumerable<Participation> CreateParticipations(EmsState state, bool adjustTime)
-    {
-        foreach (var emsParticipation in state.Participations)
-        {
-            foreach (var competitionId in emsParticipation.CompetitionsIds)
-            {
-                var competition = state.Event.Competitions.First(x => x.Id == competitionId);
-                yield return ParticipationFactory.CreateCore(emsParticipation, competition, adjustTime);
-            }
-        }
-    }
-
-    private IEnumerable<Ranking> CreateClassifications(EmsState state, bool adjustTime)
+    private (IEnumerable<Ranking>, IEnumerable<Participation>) CreateRankingsAndParticipations(EmsState state, bool adjustTime)
     {
         var result = new List<Ranking>();
-        var entriesforClassification = new Dictionary<EmsCompetition, Dictionary<AthleteCategory, List<RankingEntry>>>();
+        var entriesforClassification = new Dictionary<EmsCompetition, Dictionary<AthleteCategory, List<(RankingEntry entry, Participation particpation)>>>();
         foreach (var emsParticipation in state.Participations)
         {
             foreach (var competitionId in emsParticipation.CompetitionsIds)
@@ -142,22 +129,22 @@ public class EmsToCoreImporter : IEmsToCoreImporter
                 var competition = state.Event.Competitions.First(x => x.Id == competitionId);
                 var participation = ParticipationFactory.CreateCore(emsParticipation, competition, adjustTime);
                 var category = EmsCategoryToAthleteCategory(emsParticipation.Participant.Athlete.Category);
-                var entry = new RankingEntry(participation, !emsParticipation.Participant.Unranked);
+                var entry = new RankingEntry(participation.Id, !emsParticipation.Participant.Unranked);
                 if (entriesforClassification.ContainsKey(competition) && entriesforClassification[competition].ContainsKey(category))
                 {
-                    entriesforClassification[competition][category].Add(entry);
+                    entriesforClassification[competition][category].Add((entry, participation));
                 }
                 else if (entriesforClassification.ContainsKey(competition))
                 {
-                    entriesforClassification[competition].Add(category, new List<RankingEntry> { entry });
+                    entriesforClassification[competition].Add(category, new List<(RankingEntry entry, Participation particpation)> { (entry, participation) });
                 }
                 else
                 {
                     entriesforClassification.Add(
                         competition,
-                        new Dictionary<AthleteCategory, List<RankingEntry>>
+                        new Dictionary<AthleteCategory, List<(RankingEntry entry, Participation particpation)>>
                         { 
-                            { category, new List<RankingEntry> { entry } } 
+                            { category, new List<(RankingEntry entry, Participation particpation)> { (entry, participation) } } 
                         });
                 }
 
@@ -165,12 +152,20 @@ public class EmsToCoreImporter : IEmsToCoreImporter
         }
         foreach (var (competition, entriesByCategory) in entriesforClassification)
         {
-            foreach (var (category, entries) in entriesByCategory)
+            foreach (var (category, tuples) in entriesByCategory)
             {
+                var entries = tuples.Select(x => x.entry);
                 result.Add(new Ranking(competition.Name, category, entries));
             }
+            
+
         }
-        return result;
+        var participations = entriesforClassification
+            .Values
+            .SelectMany(x => x.Values)
+            .SelectMany(x => x.Select(y => y.particpation))
+            .Distinct();
+        return (result, participations);
     }
 
     private AthleteCategory EmsCategoryToAthleteCategory(EmsCategory category)

--- a/src-v2/Judge/NTS.Judge/Adapters/Behinds/ParticipationBehind.cs
+++ b/src-v2/Judge/NTS.Judge/Adapters/Behinds/ParticipationBehind.cs
@@ -100,4 +100,9 @@ public class ParticipationBehind : ObservableBehind, IParticipationBehind
         participation.RestoreQualification();
         await _participationRepository.Update(participation);
     }
+
+    public async Task<Participation?> Get(int id)
+    {
+        return await _participationRepository.Read(id);
+    }
 }

--- a/src-v2/Judge/NTS.Judge/Adapters/Behinds/RanklistBehind.cs
+++ b/src-v2/Judge/NTS.Judge/Adapters/Behinds/RanklistBehind.cs
@@ -1,6 +1,7 @@
 ﻿using Not.Application.Ports.CRUD;
 using Not.Blazor.Ports.Behinds;
 using Not.Exceptions;
+using NTS.Domain.Core.Aggregates.Participations;
 using NTS.Domain.Core.Entities;
 using NTS.Domain.Core.Objects;
 using NTS.Judge.Blazor.Ports;
@@ -10,10 +11,12 @@ namespace NTS.Judge.Adapters.Behinds;
 public class RanklistBehind : ObservableBehind, IRanklistBehind
 {
     private readonly IRepository<Ranking> _rankings;
+    private readonly IRepository<Participation> _participations;
 
-    public RanklistBehind(IRepository<Ranking> rankings)
+    public RanklistBehind(IRepository<Ranking> rankings, IRepository<Participation> participations)
     {
         _rankings = rankings;
+        _participations = participations;
     }
 
     public Ranklist? Ranklist { get; private set; }
@@ -28,7 +31,7 @@ public class RanklistBehind : ObservableBehind, IRanklistBehind
         var ranking = await _rankings.Read(id);
         GuardHelper.ThrowIfDefault(ranking);
 
-        Ranklist = new Ranklist(ranking);
+        Ranklist = await CreateRanklist(ranking);
         EmitChange();
     }
 
@@ -40,6 +43,12 @@ public class RanklistBehind : ObservableBehind, IRanklistBehind
         {
             return;
         }
-        Ranklist = new Ranklist(ranking);
+        Ranklist = await CreateRanklist(ranking);
+    }
+
+    private async Task<Ranklist> CreateRanklist(Ranking ranking)
+    {
+        var participations = await _participations.ReadAll();
+        return new Ranklist(ranking, participations);
     }
 }

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/Participation.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/Participation.cs
@@ -12,6 +12,9 @@ public class Participation : DomainEntity, IAggregateRoot
     private static readonly FailedToQualify OUT_OF_TIME = new (FTQCodes.OT);
     private static readonly FailedToQualify SPEED_RESTRICTION = new (FTQCodes.SP);
 
+    private Participation(int id) : base(id)
+    {
+    }
     public Participation(string competition, Tandem tandem, IEnumerable<Phase> phases)
     {
         Competition = competition;

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/Phase.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/Phase.cs
@@ -3,6 +3,7 @@ using static NTS.Domain.Core.Aggregates.Participations.SnapshotResultType;
 
 namespace NTS.Domain.Core.Aggregates.Participations;
 
+// TODO: probably should be a record
 public class Phase : DomainEntity, IPhaseState
 {
     internal string InternalGate { get; set; }

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/PhaseCollection.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/PhaseCollection.cs
@@ -14,11 +14,11 @@ public class PhaseCollection : ReadOnlyCollection<Phase>
             var distanceFromStart = gate += phase.Length;
             phase.InternalGate = $"{i + 1}/{distanceFromStart:0.##}";
         }
-        Current = this.FirstOrDefault(x => !x.IsComplete);
+        Current = this.FirstOrDefault(x => x.IsComplete) ?? this.Last();
     }
 
     public Phase? CurrentComplete => this.LastOrDefault(x => x.IsComplete);
-    internal Phase? Current { get; private set; } 
+    public Phase? Current { get; private set; } 
     internal int CurrentNumber => this.NumberOf(Current ?? this.Last());
     public double Distance => this.Sum(x => x.Length);
     internal Timestamp? OutTime => this.LastOrDefault(x => x.OutTime != null)?.OutTime;

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/PhaseCollection.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/PhaseCollection.cs
@@ -14,7 +14,7 @@ public class PhaseCollection : ReadOnlyCollection<Phase>
             var distanceFromStart = gate += phase.Length;
             phase.InternalGate = $"{i + 1}/{distanceFromStart:0.##}";
         }
-        Current = this.FirstOrDefault(x => x.IsComplete) ?? this.Last();
+        Current = this.LastOrDefault(x => x.IsComplete) ?? this.First();
     }
 
     public Phase? CurrentComplete => this.LastOrDefault(x => x.IsComplete);

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/SnapshotResult.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/SnapshotResult.cs
@@ -2,9 +2,9 @@
 
 public class SnapshotResult : DomainEntity
 {
-#pragma warning disable CS8618 // Deserialization ctor
-    private SnapshotResult() { }
-#pragma warning restore CS8618 
+    private SnapshotResult(int id) : base(id)
+    {
+    }
 
     public static SnapshotResult Applied(Snapshot snapshot) => new(snapshot, SnapshotResultType.Applied);
     public static SnapshotResult NotApplied(Snapshot snapshot, SnapshotResultType type) => new(snapshot, type);

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/SnapshotResult.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/SnapshotResult.cs
@@ -1,14 +1,16 @@
-﻿namespace NTS.Domain.Core.Aggregates.Participations;
+﻿using Newtonsoft.Json;
+
+namespace NTS.Domain.Core.Aggregates.Participations;
 
 public class SnapshotResult : DomainEntity
 {
+    public static SnapshotResult Applied(Snapshot snapshot) => new(snapshot, SnapshotResultType.Applied);
+    public static SnapshotResult NotApplied(Snapshot snapshot, SnapshotResultType type) => new(snapshot, type);
+    
+    [JsonConstructor]
     private SnapshotResult(int id) : base(id)
     {
     }
-
-    public static SnapshotResult Applied(Snapshot snapshot) => new(snapshot, SnapshotResultType.Applied);
-    public static SnapshotResult NotApplied(Snapshot snapshot, SnapshotResultType type) => new(snapshot, type);
-
     private SnapshotResult(Snapshot snapshot, SnapshotResultType type)
     {
         Snapshot = snapshot;

--- a/src-v2/NTS.Domain.Core/Aggregates/Participations/Tandem.cs
+++ b/src-v2/NTS.Domain.Core/Aggregates/Participations/Tandem.cs
@@ -2,10 +2,14 @@
 
 namespace NTS.Domain.Core.Aggregates.Participations;
 
+// TODO: probably shoudl be a record
 public class Tandem : DomainEntity
 {
     private decimal _distance;
 
+    private Tandem(int id) : base(id)
+    {
+    }
     public Tandem(
         int number,
         Person name,

--- a/src-v2/NTS.Domain.Core/Entities/Event.cs
+++ b/src-v2/NTS.Domain.Core/Entities/Event.cs
@@ -1,11 +1,14 @@
-﻿using Newtonsoft.Json;
+﻿using JsonNet.PrivatePropertySetterResolver;
+using Newtonsoft.Json;
 using NTS.Domain.Core.Objects;
 
 namespace NTS.Domain.Core.Entities;
 
 public class Event : DomainEntity
 {
-    [JsonConstructor]
+    private Event(int id) : base(id)
+    {
+    }
     public Event(
         Country country,
         string city,

--- a/src-v2/NTS.Domain.Core/Entities/Handout.cs
+++ b/src-v2/NTS.Domain.Core/Entities/Handout.cs
@@ -4,7 +4,10 @@ namespace NTS.Domain.Core.Entities;
 
 public class Handout : DomainEntity
 {
-    private Handout()
+    // TODO: Investigate why this cannot deserialize without private ctor, but Officials can
+    // It's because Official's parameters are identical to it's properties while Hangout's arent
+    // How to approach this consistently?
+    private Handout(int id) : base(id)
     {
     }
     public Handout(Participation participation)

--- a/src-v2/NTS.Domain.Core/Entities/Handout.cs
+++ b/src-v2/NTS.Domain.Core/Entities/Handout.cs
@@ -1,4 +1,5 @@
-﻿using NTS.Domain.Core.Aggregates.Participations;
+﻿using Newtonsoft.Json;
+using NTS.Domain.Core.Aggregates.Participations;
 
 namespace NTS.Domain.Core.Entities;
 
@@ -7,17 +8,14 @@ public class Handout : DomainEntity
     // TODO: Investigate why this cannot deserialize without private ctor, but Officials can
     // It's because Official's parameters are identical to it's properties while Hangout's arent
     // How to approach this consistently?
+    [JsonConstructor]
     private Handout(int id) : base(id)
     {
     }
     public Handout(Participation participation)
     {
-        Competition = participation.Competition;
-        Tandem = participation.Tandem;
-        Phases = participation.Phases;
+        ParticipationId = participation.Id;
     }
 
-    public string Competition { get; private set; } = default!;
-    public Tandem Tandem { get; private set; } = default!;
-    public PhaseCollection Phases { get; private set; } = default!;
+    public int ParticipationId { get; private set; }
 }

--- a/src-v2/NTS.Domain.Core/Entities/Official.cs
+++ b/src-v2/NTS.Domain.Core/Entities/Official.cs
@@ -2,6 +2,9 @@
 
 public class Official : DomainEntity
 {
+    private Official(int id) : base(id)
+    {
+    }
     public Official(Person person, OfficialRole role)
     {
         Person = person;

--- a/src-v2/NTS.Domain.Core/Entities/Ranking.cs
+++ b/src-v2/NTS.Domain.Core/Entities/Ranking.cs
@@ -5,6 +5,9 @@ namespace NTS.Domain.Core.Entities;
 
 public class Ranking : DomainEntity, IAggregateRoot
 {
+    private Ranking(int id) : base(id)
+    {
+    }
     public Ranking(string name, AthleteCategory category, IEnumerable<RankingEntry> entries)
     {
         Name = name;

--- a/src-v2/NTS.Domain.Core/Entities/RankingEntry.cs
+++ b/src-v2/NTS.Domain.Core/Entities/RankingEntry.cs
@@ -4,12 +4,20 @@ namespace NTS.Domain.Core.Entities;
 
 public class RankingEntry : DomainEntity
 {
-    public RankingEntry(Participation participation, bool isRanked)
+    private RankingEntry(int id) : base(id)
     {
-        Participation = participation;
+    }
+    public RankingEntry(int participationId, bool isRanked)
+    {
+        ParticipationId = participationId;
         IsRanked = isRanked;
     }
 
-    public Participation Participation { get; private set; }
+    public int ParticipationId { get; private set; }
     public bool IsRanked { get; private set; }
+
+    public override string ToString()
+    {
+        return $"IsRanked: {IsRanked}, {ParticipationId}";
+    }
 }

--- a/src-v2/NTS.Domain.Core/GlobalSuppressions.cs
+++ b/src-v2/NTS.Domain.Core/GlobalSuppressions.cs
@@ -1,0 +1,22 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Aggregates.Participations.Phase.#ctor(System.Double,System.Int32,System.Int32,NTS.Domain.Enums.CompetitionType,System.Boolean,System.Nullable{System.Int32})")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Aggregates.Participations.SnapshotResult.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Aggregates.Participations.SnapshotResult.#ctor(System.Int32)")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Aggregates.Participations.Tandem.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Aggregates.Participations.Tandem.#ctor(System.Int32)")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Event.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Event.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Handout.#ctor(System.Int32)")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Official.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Official.#ctor(System.Int32)")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Ranking.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.Ranking.#ctor(System.Int32)")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Entities.RankingEntry.#ctor(System.Int32)")]
+[assembly: SuppressMessage("Compiler", "CS8618:Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Objects.DocumentHeader.#ctor")]
+[assembly: SuppressMessage("CodeQuality", "IDE0051:Remove unused private members", Justification = "<Pending>", Scope = "member", Target = "~M:NTS.Domain.Core.Services.DocumentProducer.Produce``1(``0)")]

--- a/src-v2/NTS.Domain.Core/Objects/HandoutDocument.cs
+++ b/src-v2/NTS.Domain.Core/Objects/HandoutDocument.cs
@@ -5,11 +5,11 @@ namespace NTS.Domain.Core.Objects;
 
 public record HandoutDocument : DomainObject
 {
-    public HandoutDocument(Handout handout, Event @event, IEnumerable<Official> officials)
+    public HandoutDocument(Participation participation, Event enduranceEvent, IEnumerable<Official> officials)
     {
-        Header = new DocumentHeader(handout.Competition, @event.PopulatedPlace, @event.EventSpan, officials);
-        Tandem = handout.Tandem;
-        Phases = handout.Phases;
+        Header = new DocumentHeader(participation.Competition, enduranceEvent.PopulatedPlace, enduranceEvent.EventSpan, officials);
+        Tandem = participation.Tandem;
+        Phases = participation.Phases;
     }
 
     public DocumentHeader Header { get; }

--- a/src-v2/NTS.Domain.Core/Objects/Ranklist.cs
+++ b/src-v2/NTS.Domain.Core/Objects/Ranklist.cs
@@ -1,14 +1,13 @@
-﻿using NTS.Domain.Core.Entities;
+﻿using NTS.Domain.Core.Aggregates.Participations;
+using NTS.Domain.Core.Entities;
 using System.Collections.ObjectModel;
 
 namespace NTS.Domain.Core.Objects;
 
 public class Ranklist : ReadOnlyCollection<RankingEntry>
 {
-    public Ranklist(Ranking ranking)
-        : base(ranking.Category == AthleteCategory.Senior
-            ? RankSeniors(ranking.Entries)
-            : RankOthers(ranking.Entries))
+    public Ranklist(Ranking ranking, IEnumerable<Participation> participations)
+        : base(Rank(ranking.Entries, participations))
     {
         Name = ranking.Name;
         Category = ranking.Category;
@@ -18,26 +17,16 @@ public class Ranklist : ReadOnlyCollection<RankingEntry>
     public string Name { get; }
     public AthleteCategory Category { get; }
 
-    private static IList<RankingEntry> RankSeniors(IEnumerable<RankingEntry> entry)
+    private static IList<RankingEntry> Rank(IEnumerable<RankingEntry> entries, IEnumerable<Participation> participations)
     {
-        var ranked = OrderByNotQualifiedThenNotRanked(entry)
-            .ThenBy(x => x.Participation.Phases.Last().ArriveTime)
-            .ToList();
-        return ranked;
-    }
-
-    private static IList<RankingEntry> RankOthers(IEnumerable<RankingEntry> entry)
-    {
-        var ranked = OrderByNotQualifiedThenNotRanked(entry)
-            .ThenBy(x => x.Participation.Total?.RecoveryInterval)
-            .ToList();
-        return ranked;
-    }
-
-    private static IOrderedEnumerable<RankingEntry> OrderByNotQualifiedThenNotRanked(IEnumerable<RankingEntry> entry)
-    {
-        return entry
+        var ids = entries.Select(x => x.ParticipationId).ToList();
+        var ranked = entries
+            .Select(x => new { Entry = x, Participation = participations.First(y => x.ParticipationId == y.Id) })
             .OrderBy(x => x.Participation.IsNotQualified)
-            .ThenByDescending(x => !x.IsRanked);
+            .ThenByDescending(x => !x.Entry.IsRanked)
+            .ThenBy(x => x.Participation.Phases.Last().ArriveTime)
+            .Select(x => x.Entry)
+            .ToList();
+        return ranked;
     }
 }

--- a/src-v2/NTS.Domain.Core/Services/DocumentProducer.cs
+++ b/src-v2/NTS.Domain.Core/Services/DocumentProducer.cs
@@ -9,11 +9,12 @@ public class DocumentProducer // TODO: remove
 {
     public static void CreateRanklist(Event @event, IEnumerable<Official> officials, Ranking classification)
     {
-        var ranklist = new Ranklist(classification);
+        // TODO: use RanklistDocument in RanklistTable
+        //var ranklist = new Ranklist(classification);
 
-        var header = new DocumentHeader(classification.Name, @event.PopulatedPlace, @event.EventSpan, officials);
-        var ranklistDocument = new RanklistDocument(header, ranklist);
-        Produce(ranklistDocument);
+        //var header = new DocumentHeader(classification.Name, @event.PopulatedPlace, @event.EventSpan, officials);
+        //var ranklistDocument = new RanklistDocument(header, ranklist);
+        //Produce(ranklistDocument);
     }
 
     private static void Produce<T>(T document)

--- a/src-v2/Not/Not.Domain/DomainEntity.cs
+++ b/src-v2/Not/Not.Domain/DomainEntity.cs
@@ -1,9 +1,14 @@
-﻿using Not.Random;
+﻿using Newtonsoft.Json;
+using Not.Random;
 
 namespace Not.Domain;
 
 public abstract class DomainEntity : IEquatable<DomainEntity>, IIdentifiable
 {
+    protected DomainEntity(int id)
+    {
+        Id = id;
+    }
     protected DomainEntity()
     {
         this.Id = RandomHelper.GenerateUniqueInteger();


### PR DESCRIPTION
Use Participation ID instead of actually referencing participation instance in `Ranking` and `Handouts`. This ensures that there is no duplication of Participation data in CoreState.json